### PR TITLE
make autophase respect verbose setting

### DIFF
--- a/impact/fast_autophase.py
+++ b/impact/fast_autophase.py
@@ -315,10 +315,10 @@ def fast_autophase_impact(
 
         rel_phase_deg = None  # does not set
         if settings:
-            #print(f'------------ {name}')
             if name in settings:
                 rel_phase_deg = settings[name]
-                print(f"Setting {name} relative phase = {rel_phase_deg} deg")
+                if verbose:
+                    print(f"Setting {name} relative phase = {rel_phase_deg} deg")
 
         out = fast_autophase_ele(
             ele,


### PR DESCRIPTION
Found a print statement in the phasing section which doesn't listen to the verbose setting. Useful to quiet down output if running many times.