### PR TITLE
ENH: support 0 for auto-detect number of processes for `Impact` commands

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - distgen
   - matplotlib
   - bokeh
+  - psutil
   - jupyter_bokeh
   #- impact-t=*=mpi_openmpi*
   - impact-t=*=mpi_mpich*

--- a/impact/impact.py
+++ b/impact/impact.py
@@ -311,7 +311,11 @@ class Impact(CommandWrapper):
     @numprocs.setter
     def numprocs(self, n):
         """Sets the number of processors"""
-        assert n > 0, 'numprocs must be positive'
+        if n < 0:
+            raise ValueError("numprocs must be >= 0")
+        if not n:
+            n = tools.get_suggested_nproc()
+
         Nz = self.header['Nz']
         Ny = self.header['Ny']
         Npcol, Nprow = suggested_processor_domain(Nz, Ny, n)

--- a/impact/tools.py
+++ b/impact/tools.py
@@ -1,13 +1,14 @@
-import subprocess
-import platform
-import os, errno
-from hashlib import blake2b
-from copy import deepcopy
-import numpy as np
-import json
-import shutil
 import datetime
+import json
+import os
+import platform
+import shutil
+import subprocess
+from copy import deepcopy
+from hashlib import blake2b
 
+import numpy as np
+import psutil
 
 
 def parse_float(s):
@@ -271,3 +272,8 @@ def find_workdir():
         return os.environ.get('SCRATCH')
     else:
         return None
+
+
+def get_suggested_nproc() -> int:
+    """Get the suggested number of processes to use for MPI."""
+    return psutil.cpu_count(logical=False)


### PR DESCRIPTION
## Notes

* To rebase after #21 is merged
* Goal is to support "0" as the number of processes for MPI
    * It's convenient to let MPI choose the right number of processes when running on hardware that's not our own.
    * `psutil.cpu_count(logical=False)` reports the correct number of cores on all platforms that we've tested on
* Side note: the standard library-recommended method did *not* work under a virtualized environment

Specifically, for a [GitHub Actions runner with 2 cores](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) (and 2 threads/core):
```
$ lscpu --extended
CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE
  0    0      0    0 0:0:0:0          yes
  1    0      0    0 0:0:0:0          yes
  2    0      0    1 1:1:1:0          yes
  3    0      0    1 1:1:1:0          yes
```

And:
```
os.sched_affinity: {0, 1, 2, 3} => 4
psutil proc affinity: [0, 1, 2, 3] => 4
psutil.cpu_count(logical=True) = 4
psutil.cpu_count(logical=False) = 2
```

With each having a separate affinity, it appears to indicate each logical thread is running on a different core. That doesn't really make sense (as far as my limited understanding goes) and thus breaks the recommendation in the standard library.

Regardless, the foolproof method here that `mpirun`/`openmpi` agrees with is `psutil.cpu_cout(logical=False)` and as such that's what I've used here.