### PR TITLE
DOC/BLD: remove polyfill

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,7 +74,6 @@ markdown_extensions:
       
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js      
 
 extra:


### PR DESCRIPTION
It seems `polyfill` is no longer required per the docs: https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax-mkdocsyml And it's perhaps also a security concern.