### PR TITLE
FIX: pytao `ele_grid_field` changes

### DIFF
--- a/impact/interfaces/bmad.py
+++ b/impact/interfaces/bmad.py
@@ -100,8 +100,8 @@ def tao_create_impact_emfield_cartesian_ele(
         name = edat["name"]
 
     # FieldMesh
-    grid_params = tao.ele_grid_field(ix_ele, 1, "base", as_dict=False)
-    field_file = grid_params["file"].value
+    grid_params = tao.ele_grid_field(ix_ele, 1, "base")
+    field_file = grid_params["file"]
     if cache is not None:
         if field_file in cache:
             field_mesh = cache[field_file]
@@ -117,7 +117,7 @@ def tao_create_impact_emfield_cartesian_ele(
         raise NotImplementedError("oscillating fields not yet implemented")
 
     # Scaling
-    master_parameter = grid_params["master_parameter"].value
+    master_parameter = grid_params["master_parameter"]
     if master_parameter == "<None>":
         master_parameter = "FIELD_AUTOSCALE"
     scale = edat[master_parameter]
@@ -251,8 +251,8 @@ def tao_create_impact_solrf_ele(
         name = edat["name"]
 
     # FieldMesh
-    grid_params = tao.ele_grid_field(ix_ele, 1, "base", as_dict=False)
-    field_file = grid_params["file"].value
+    grid_params = tao.ele_grid_field(ix_ele, 1, "base")
+    field_file = grid_params["file"]
     if cache is not None:
         if field_file in cache:
             field_mesh = cache[field_file]
@@ -269,7 +269,7 @@ def tao_create_impact_solrf_ele(
     assert np.allclose(freq, field_mesh.frequency), f"{freq} != {field_mesh.frequency}"
 
     # master_parameter = field_mesh.attrs.get('masterParameter', None)
-    master_parameter = grid_params["master_parameter"].value
+    master_parameter = grid_params["master_parameter"]
     if master_parameter == "<None>":
         master_parameter = None
 
@@ -322,7 +322,7 @@ def tao_create_impact_solrf_ele(
         phi0_ref = freq * ref_time_start
 
         # phi0_fieldmap = field_mesh.attrs['RFphase'] / (2*np.pi) # Bmad doesn't use at this point
-        phi0_fieldmap = grid_params["phi0_fieldmap"].value
+        phi0_fieldmap = grid_params["phi0_fieldmap"]
 
         # Phase based on absolute time tracking
         phi0_user = sum([edat["PHI0"], edat["PHI0_ERR"]])
@@ -484,8 +484,7 @@ def tao_create_impact_lattice_and_fieldmaps(
 
     # Make a dict of field_file:file_id
     field_files = {
-        ele_ix: tao.ele_grid_field(ele_ix, 1, "base", as_dict=False)["file"].value
-        for ele_ix in ele_ixs
+        ele_ix: tao.ele_grid_field(ele_ix, 1, "base")["file"] for ele_ix in ele_ixs
     }
     # Make file_id lookup table
     file_id_lookup = {}


### PR DESCRIPTION
* `Tao.ele_grid_field` returns a dictionary of key mapped to Python value, something like this:
   ```
    {'dr': array([0.005, 0.5, 0.     ]),
     'r0': array([0., 0., 0.]),
     'master_parameter': 'VOLTAGE',
     'ele_anchor_pt': 'Beginning',
     'field_type': 'Electric',
     'grid_field^geometry': 'rotationally_symmetric_rz',
     'harmonic': 0,
     'phi0_fieldmap': 0.0,
     'field_scale': 1.0,
     'interpolation_order': 1,
     'curved_ref_frame': False,
     'file': '...'}
    ```

* The current codebase assumes an older version of pytao where it returned parameters with `.value`