### PR TITLE
!= -> not np.isclose

### DIFF
--- a/impact/interfaces/bmad.py
+++ b/impact/interfaces/bmad.py
@@ -127,7 +127,7 @@ def tao_create_impact_emfield_cartesian_ele(
     z1 = field_mesh.zmax
     L_fm = z1 - z0
     L_ele = edat["L"]
-    if L_fm != L_ele:
+    if not np.isclose(L_fm, L_ele):
         raise NotImplementedError(
             f"Element length {L_ele} currently must be the same as the fieldmap length {L_fm}"
         )

--- a/impact/interfaces/bmad.py
+++ b/impact/interfaces/bmad.py
@@ -129,7 +129,7 @@ def tao_create_impact_emfield_cartesian_ele(
     L_ele = edat["L"]
     if not np.isclose(L_fm, L_ele):
         raise NotImplementedError(
-            f"Element length {L_ele} currently must be the same as the fieldmap length {L_fm}"
+            f"Element {ele_id} length {L_ele} currently must be the same as the fieldmap length {L_fm}"
         )
 
     # Find zedge


### PR DESCRIPTION
This relaxes the restriction for `emfield_cartesian` fieldmaps from Tao to use `np.isclose`