### PR TITLE
Add new_write_beam for MONITOR::* elements

### DIFF
--- a/impact/impact.py
+++ b/impact/impact.py
@@ -976,8 +976,10 @@ class Impact(CommandWrapper):
 
     @classmethod
     @functools.wraps(impact_from_tao)
-    def from_tao(cls, tao, fieldmap_style="fourier", n_coef=30):
-        return impact_from_tao(tao, fieldmap_style=fieldmap_style, n_coef=n_coef)
+    def from_tao(cls, tao, fieldmap_style="fourier", n_coef=30, **kwargs):
+        return impact_from_tao(
+            tao, fieldmap_style=fieldmap_style, n_coef=n_coef, **kwargs
+        )
 
     def __getitem__(self, key):
         """

--- a/impact/particles.py
+++ b/impact/particles.py
@@ -56,7 +56,8 @@ def track_to_s(impact_object, particles, s):
     impact_object.run()
 
     if "particles" in impact_object.output:
-        return impact_object.output["particles"]["final_particles"]
+        particles = impact_object.output["particles"]
+        return particles.get("final_particles", None)
     else:
         return None
 


### PR DESCRIPTION
This adds options to `Impact.from_tao`:
- `emfield_cartesian_eles="EM_FIELD::*"`
- `solrf_eles="E_GUN::*,SOLENOID::*,LCAVITY::*"`
- `quadrupole_eles="quad::*"`
- `write_beam_eles="monitor::*"`

These can either be a match condition for Tao, or a list of element names or indexes.