### PR TITLE
Update beamphysics imports

### DIFF
--- a/docs/examples/autophase_example.ipynb
+++ b/docs/examples/autophase_example.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "from impact.autophase import autophase_and_scale\n",
     "\n",
-    "from pmd_beamphysics import single_particle\n",
+    "from beamphysics import single_particle\n",
     "\n",
     "P0 = single_particle(pz=1e-15, z=1e-15)"
    ]

--- a/docs/examples/bmad_to_impact/corrector_coil/bmad_to_impact.ipynb
+++ b/docs/examples/bmad_to_impact/corrector_coil/bmad_to_impact.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "from pytao import Tao\n",
-    "from pmd_beamphysics import FieldMesh\n",
+    "from beamphysics import FieldMesh\n",
     "import numpy as np\n",
     "import os\n",
     "\n",
@@ -50,7 +50,7 @@
     "    tao_create_impact_lattice_and_fieldmaps,\n",
     "    impact_from_tao,\n",
     ")\n",
-    "from pmd_beamphysics.fields.corrector_modeling import make_dipole_corrector_fieldmesh\n",
+    "from beamphysics.fields.corrector_modeling import make_dipole_corrector_fieldmesh\n",
     "\n",
     "\n",
     "import matplotlib.pyplot as plt"

--- a/docs/examples/bmad_to_impact/corrector_coil/compare.ipynb
+++ b/docs/examples/bmad_to_impact/corrector_coil/compare.ipynb
@@ -31,7 +31,7 @@
     "from impact.interfaces.bmad import (\n",
     "    impact_from_tao,\n",
     ")\n",
-    "from pmd_beamphysics.fields.corrector_modeling import make_dipole_corrector_fieldmesh\n",
+    "from beamphysics.fields.corrector_modeling import make_dipole_corrector_fieldmesh\n",
     "\n",
     "\n",
     "import matplotlib.pyplot as plt"

--- a/docs/examples/compare_covariance.ipynb
+++ b/docs/examples/compare_covariance.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "import numpy as np\n",
     "from pathlib import Path\n",
-    "from pmd_beamphysics.units import c_light\n",
+    "from beamphysics.units import c_light\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "%config InlineBackend.figure_format = 'retina'\n",

--- a/docs/examples/devel/devel_solrf_fieldmaps.ipynb
+++ b/docs/examples/devel/devel_solrf_fieldmaps.ipynb
@@ -114,7 +114,7 @@
    },
    "outputs": [],
    "source": [
-    "from pmd_beamphysics.interfaces.impact import create_fourier_coefficients\n",
+    "from beamphysics.interfaces.impact import create_fourier_coefficients\n",
     "\n",
     "N_COEF = 20\n",
     "\n",
@@ -173,7 +173,7 @@
    },
    "outputs": [],
    "source": [
-    "from pmd_beamphysics.interfaces.impact import fourier_field_reconsruction"
+    "from beamphysics.interfaces.impact import fourier_field_reconsruction"
    ]
   },
   {
@@ -226,7 +226,7 @@
    },
    "outputs": [],
    "source": [
-    "from pmd_beamphysics.interfaces.impact import create_fourier_coefficients_via_fft"
+    "from beamphysics.interfaces.impact import create_fourier_coefficients_via_fft"
    ]
   },
   {
@@ -423,7 +423,7 @@
    },
    "outputs": [],
    "source": [
-    "from pmd_beamphysics.fields.expansion import (\n",
+    "from beamphysics.fields.expansion import (\n",
     "    fft_derivative_array,\n",
     "    spline_derivative_array,\n",
     ")\n",

--- a/docs/examples/elements/corrector_coil.ipynb
+++ b/docs/examples/elements/corrector_coil.ipynb
@@ -31,7 +31,7 @@
     "from scipy.constants import c\n",
     "import os\n",
     "\n",
-    "from pmd_beamphysics.fields.corrector_modeling import make_dipole_corrector_fieldmesh\n",
+    "from beamphysics.fields.corrector_modeling import make_dipole_corrector_fieldmesh\n",
     "\n",
     "from impact import Impact"
    ]

--- a/docs/examples/elements/drift.ipynb
+++ b/docs/examples/elements/drift.ipynb
@@ -43,7 +43,7 @@
    },
    "outputs": [],
    "source": [
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics.units import mec2\n",
     "\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/examples/elements/quadrupole.ipynb
+++ b/docs/examples/elements/quadrupole.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "from impact import Impact\n",
     "\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics.units import mec2\n",
     "\n",
     "import numpy as np\n",
     "import os\n",

--- a/docs/examples/elements/tesla_9cell_cavity.ipynb
+++ b/docs/examples/elements/tesla_9cell_cavity.ipynb
@@ -22,7 +22,7 @@
    "outputs": [],
    "source": [
     "from impact import Impact\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics.units import mec2\n",
     "import numpy as np\n",
     "import os\n",
     "\n",
@@ -252,7 +252,7 @@
    "source": [
     "from impact.autophase import autophase\n",
     "\n",
-    "from pmd_beamphysics import single_particle\n",
+    "from beamphysics import single_particle\n",
     "\n",
     "P0 = single_particle(pz=10e6, z=1e-15)\n",
     "\n",

--- a/docs/examples/elements/traveling_wave_cavity.ipynb
+++ b/docs/examples/elements/traveling_wave_cavity.ipynb
@@ -536,7 +536,7 @@
    "source": [
     "from impact.autophase import autophase_and_scale\n",
     "\n",
-    "from pmd_beamphysics import single_particle\n",
+    "from beamphysics import single_particle\n",
     "\n",
     "# Start particles at 1.4 m, just in front of the cavity\n",
     "P0 = single_particle(pz=6e6, z=1.4)"

--- a/docs/examples/fieldmap_reconstruction.ipynb
+++ b/docs/examples/fieldmap_reconstruction.ipynb
@@ -23,7 +23,7 @@
    "outputs": [],
    "source": [
     "from impact import Impact, fieldmaps\n",
-    "from pmd_beamphysics.interfaces.impact import create_fourier_coefficients\n",
+    "from beamphysics.interfaces.impact import create_fourier_coefficients\n",
     "import numpy as np"
    ]
   },

--- a/docs/examples/point_to_point_spacecharge.ipynb
+++ b/docs/examples/point_to_point_spacecharge.ipynb
@@ -29,7 +29,7 @@
     "from distgen import Generator\n",
     "import os\n",
     "\n",
-    "from pmd_beamphysics.units import e_charge, mec2\n",
+    "from beamphysics.units import e_charge, mec2\n",
     "\n",
     "import matplotlib.pyplot as plt"
    ]

--- a/docs/examples/z/basic/basic_impact_z.ipynb
+++ b/docs/examples/z/basic/basic_impact_z.ipynb
@@ -33,7 +33,7 @@
     "from impact import ImpactZ\n",
     "import impact.z as IZ\n",
     "\n",
-    "from pmd_beamphysics.units import mec2, c_light\n",
+    "from beamphysics.units import mec2, c_light\n",
     "import numpy as np\n",
     "import os"
    ]

--- a/docs/examples/z/elements/collimator-bmad.ipynb
+++ b/docs/examples/z/elements/collimator-bmad.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from pmd_beamphysics import ParticleGroup\n",
+    "from beamphysics import ParticleGroup\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/compare-particle-stats.ipynb
+++ b/docs/examples/z/elements/compare-particle-stats.ipynb
@@ -19,8 +19,8 @@
     "import impact.z as IZ\n",
     "from impact.z import WriteFull, Drift, ImpactZOutput\n",
     "\n",
-    "from pmd_beamphysics import ParticleGroup\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import ParticleGroup\n",
+    "from beamphysics.units import mec2\n",
     "\n",
     "from scipy.constants import c"
    ]
@@ -173,9 +173,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics.units import mec2\n",
     "\n",
-    "from pmd_beamphysics.statistics import twiss_calc\n",
+    "from beamphysics.statistics import twiss_calc\n",
     "\n",
     "\n",
     "def simple_twiss(pg: ParticleGroup, plane, p0c):\n",

--- a/docs/examples/z/elements/csr-bench-bmad.ipynb
+++ b/docs/examples/z/elements/csr-bench-bmad.ipynb
@@ -13,7 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pmd_beamphysics import ParticleGroup\n",
+    "from beamphysics import ParticleGroup\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/csr-zeuthen.ipynb
+++ b/docs/examples/z/elements/csr-zeuthen.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from pmd_beamphysics import ParticleGroup\n",
+    "from beamphysics import ParticleGroup\n",
     "from pytao import Tao\n",
     "from scipy.constants import c\n",
     "\n",

--- a/docs/examples/z/elements/decapole-bmad.ipynb
+++ b/docs/examples/z/elements/decapole-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/dipole-bmad.ipynb
+++ b/docs/examples/z/elements/dipole-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/dipole.ipynb
+++ b/docs/examples/z/elements/dipole.ipynb
@@ -13,8 +13,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "\n",
     "import impact.z as IZ"
    ]

--- a/docs/examples/z/elements/drift-bmad.ipynb
+++ b/docs/examples/z/elements/drift-bmad.ipynb
@@ -16,8 +16,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/drift.ipynb
+++ b/docs/examples/z/elements/drift.ipynb
@@ -15,8 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "\n",
     "import impact.z as IZ"
    ]

--- a/docs/examples/z/elements/lcavity-bmad.ipynb
+++ b/docs/examples/z/elements/lcavity-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/octupole-bmad.ipynb
+++ b/docs/examples/z/elements/octupole-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/optics-matching-bmad.ipynb
+++ b/docs/examples/z/elements/optics-matching-bmad.ipynb
@@ -16,8 +16,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/quadrupole-bmad.ipynb
+++ b/docs/examples/z/elements/quadrupole-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/sextupole-bmad.ipynb
+++ b/docs/examples/z/elements/sextupole-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/solenoid-bmad.ipynb
+++ b/docs/examples/z/elements/solenoid-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/elements/spacecharge-benchmark.ipynb
+++ b/docs/examples/z/elements/spacecharge-benchmark.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "from scipy.constants import c\n",
     "\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics.units import mec2\n",
     "\n",
     "import numpy as np"
    ]

--- a/docs/examples/z/elements/spacecharge-drift-bmad.ipynb
+++ b/docs/examples/z/elements/spacecharge-drift-bmad.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from pmd_beamphysics import ParticleGroup\n",
+    "from beamphysics import ParticleGroup\n",
     "from pytao import Tao\n",
     "from scipy.constants import c\n",
     "\n",

--- a/docs/examples/z/elements/traveling_wave_rf_cavity.ipynb
+++ b/docs/examples/z/elements/traveling_wave_rf_cavity.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "\n",
     "import impact.z as IZ\n",
     "from impact.z import ImpactZInput"

--- a/docs/examples/z/elements/wiggler-bmad.ipynb
+++ b/docs/examples/z/elements/wiggler-bmad.ipynb
@@ -14,8 +14,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from pmd_beamphysics import single_particle\n",
-    "from pmd_beamphysics.units import mec2\n",
+    "from beamphysics import single_particle\n",
+    "from beamphysics.units import mec2\n",
     "from pytao import Tao\n",
     "\n",
     "import impact.z as IZ\n",

--- a/docs/examples/z/example2/example2.ipynb
+++ b/docs/examples/z/example2/example2.ipynb
@@ -16,7 +16,7 @@
    "source": [
     "from impact.z import ImpactZ\n",
     "from impact.z.input import WriteFull\n",
-    "from pmd_beamphysics.units import mec2"
+    "from beamphysics.units import mec2"
    ]
   },
   {

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - jupyter_bokeh
   - lume-base
   - matplotlib
-  - openpmd-beamphysics
+  - openpmd-beamphysics>=0.14.0
   - polars
   - prettytable
   - psutil

--- a/impact/archive.py
+++ b/impact/archive.py
@@ -1,7 +1,7 @@
 # import numpy as np
 
-from pmd_beamphysics.units import write_dataset_and_unit_h5, read_dataset_and_unit_h5
-from pmd_beamphysics import ParticleGroup, FieldMesh
+from beamphysics.units import write_dataset_and_unit_h5, read_dataset_and_unit_h5
+from beamphysics import ParticleGroup, FieldMesh
 
 from .parsers import header_lines
 from .lattice import lattice_lines

--- a/impact/fast_autophase.py
+++ b/impact/fast_autophase.py
@@ -1,17 +1,17 @@
 import numpy as np
 
-from pmd_beamphysics.fields.analysis import (
+from beamphysics.fields.analysis import (
     accelerating_voltage_and_phase,
     track_field_1df,
 )
 from scipy.optimize import brent
 
 from .fieldmaps import ele_field
-from pmd_beamphysics.units import mec2
+from beamphysics.units import mec2
 from scipy.constants import c
 from scipy.constants import e as e_charge
 
-from pmd_beamphysics import single_particle
+from beamphysics import single_particle
 
 
 AUTOPHASE_ATTRS = ("theta0_deg", "dtheta0_deg")

--- a/impact/fieldmaps.py
+++ b/impact/fieldmaps.py
@@ -7,8 +7,8 @@ from subprocess import Popen, PIPE
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 import warnings
 
-from pmd_beamphysics.interfaces.impact import fourier_field_reconsruction
-from pmd_beamphysics import FieldMesh
+from beamphysics.interfaces.impact import fourier_field_reconsruction
+from beamphysics import FieldMesh
 
 
 def write_fieldmap(filePath, fieldmap):

--- a/impact/impact.py
+++ b/impact/impact.py
@@ -24,9 +24,9 @@ from .fast_autophase import fast_autophase_impact
 from .interfaces.bmad import impact_from_tao
 
 
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import pmd_unit
-from pmd_beamphysics.interfaces.impact import impact_particles_to_particle_data
+from beamphysics import ParticleGroup
+from beamphysics.units import pmd_unit
+from beamphysics.interfaces.impact import impact_particles_to_particle_data
 
 from scipy.interpolate import interp1d
 

--- a/impact/interfaces/bmad.py
+++ b/impact/interfaces/bmad.py
@@ -5,8 +5,8 @@ from collections import Counter
 from copy import deepcopy
 
 import numpy as np
-from pmd_beamphysics import FieldMesh
-from pmd_beamphysics.fields.analysis import accelerating_voltage_and_phase
+from beamphysics import FieldMesh
+from beamphysics.fields.analysis import accelerating_voltage_and_phase
 
 from ..lattice import new_write_beam
 

--- a/impact/parsers.py
+++ b/impact/parsers.py
@@ -4,8 +4,8 @@ import warnings
 
 import numpy as np
 import polars as pl
-from pmd_beamphysics.species import mass_of
-from pmd_beamphysics.units import multiply_units, unit
+from beamphysics.species import mass_of
+from beamphysics.units import multiply_units, unit
 
 from . import fieldmaps, tools
 from .particles import identify_species

--- a/impact/particles.py
+++ b/impact/particles.py
@@ -1,4 +1,4 @@
-from pmd_beamphysics.particles import single_particle
+from beamphysics.particles import single_particle
 
 import scipy.constants
 

--- a/impact/plot.py
+++ b/impact/plot.py
@@ -1,4 +1,4 @@
-from pmd_beamphysics.units import nice_array, nice_scale_prefix
+from beamphysics.units import nice_array, nice_scale_prefix
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
 
@@ -6,7 +6,7 @@ from .lattice import ele_shape, remove_element_types, ele_bounds, ele_overlaps_s
 from .fieldmaps import lattice_field, FIELD_CALC_ELE_TYPES
 import numpy as np
 
-from pmd_beamphysics.labels import mathlabel as _mathlabel
+from beamphysics.labels import mathlabel as _mathlabel
 
 
 _label_hotfixes = {

--- a/impact/tests/z/test_archive.py
+++ b/impact/tests/z/test_archive.py
@@ -9,7 +9,7 @@ import h5py
 import pytest
 import pydantic
 
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 
 from ... import z as IZ
 from ...z import ImpactZ, AnyInputElement

--- a/impact/tests/z/test_bmad.py
+++ b/impact/tests/z/test_bmad.py
@@ -8,8 +8,8 @@ from textwrap import dedent
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
-from pmd_beamphysics import ParticleGroup, single_particle
-from pmd_beamphysics.units import mec2
+from beamphysics import ParticleGroup, single_particle
+from beamphysics.units import mec2
 from pytao import SubprocessTao as Tao
 
 import impact.z as IZ

--- a/impact/tests/z/test_output.py
+++ b/impact/tests/z/test_output.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 
 from ... import z as IZ
-from pmd_beamphysics import single_particle
-from pmd_beamphysics.units import mec2
+from beamphysics import single_particle
+from beamphysics.units import mec2
 
 
 @pytest.mark.parametrize(

--- a/impact/tests/z/test_particles.py
+++ b/impact/tests/z/test_particles.py
@@ -4,8 +4,8 @@ import numpy as np
 import pytest
 from numpy.testing import assert_allclose
 
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import c_light
+from beamphysics import ParticleGroup
+from beamphysics.units import c_light
 
 from ...z.particles import ImpactZParticles
 

--- a/impact/tests/z/test_types.py
+++ b/impact/tests/z/test_types.py
@@ -3,8 +3,8 @@ from typing import Sequence
 
 import numpy as np
 import pytest
-from pmd_beamphysics import single_particle
-from pmd_beamphysics.units import pmd_unit
+from beamphysics import single_particle
+from beamphysics.units import pmd_unit
 from pydantic import BaseModel, TypeAdapter
 
 from ...z.types import NDArray, PydanticPmdUnit, PydanticParticleGroup

--- a/impact/z/archive.py
+++ b/impact/z/archive.py
@@ -11,8 +11,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 import h5py
 import numpy as np
 import pydantic
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import pmd_unit
+from beamphysics import ParticleGroup
+from beamphysics.units import pmd_unit
 
 from .. import tools
 from .types import PydanticPmdUnit

--- a/impact/z/input.py
+++ b/impact/z/input.py
@@ -28,8 +28,8 @@ from lume import tools as lume_tools
 from scipy.constants import e
 from typing_extensions import Protocol, runtime_checkable
 
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.particles import c_light
+from beamphysics import ParticleGroup
+from beamphysics.particles import c_light
 
 from ..impact import suggested_processor_domain
 from .. import tools

--- a/impact/z/interfaces/bmad.py
+++ b/impact/z/interfaces/bmad.py
@@ -21,9 +21,9 @@ from typing import (
 
 import matplotlib.pyplot as plt
 import numpy as np
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.particles import c_light
-from pmd_beamphysics.species import charge_state, mass_of
+from beamphysics import ParticleGroup
+from beamphysics.particles import c_light
+from beamphysics.species import charge_state, mass_of
 from pytao import Tao, TaoCommandError
 from typing_extensions import Literal, TypeAlias
 

--- a/impact/z/output.py
+++ b/impact/z/output.py
@@ -13,7 +13,7 @@ import pydantic
 import pydantic.alias_generators
 
 from .particles import ImpactZParticles
-from pmd_beamphysics.units import pmd_unit
+from beamphysics.units import pmd_unit
 from typing_extensions import override
 
 from .constants import DiagnosticType
@@ -521,7 +521,7 @@ class OutputStats(BaseModel):
         Twiss beta x (m) (computed)
     twiss_beta_y : ndarray
         Twiss beta y (m) (computed)
-    units : dict[str, pmd_beamphysics.units.pmd_unit]
+    units : dict[str, beamphysics.units.pmd_unit]
         Mapping of attribute name to pmd_unit.
     extra : dict[str, numpy.ndarray]
         Additional Impact-Z output data.  This is a future-proofing mechanism

--- a/impact/z/particles.py
+++ b/impact/z/particles.py
@@ -6,14 +6,14 @@ import pathlib
 from typing import Generator, NamedTuple
 
 import numpy as np
-from pmd_beamphysics import ParticleGroup
+from beamphysics import ParticleGroup
 import polars as pl
 from pydantic import Field
 
 from scipy.constants import e
 
-from pmd_beamphysics.particles import c_light
-from pmd_beamphysics.species import MASS_OF, charge_state, mass_of
+from beamphysics.particles import c_light
+from beamphysics.species import MASS_OF, charge_state, mass_of
 
 from .parsers import fix_line
 from .types import AnyPath, BaseModel, NDArray

--- a/impact/z/plot.py
+++ b/impact/z/plot.py
@@ -11,7 +11,7 @@ import numpy as np
 import pydantic.dataclasses as dataclasses
 from impact.z.constants import MultipoleType
 from impact.z.input import AnyInputElement, Multipole, ZElement
-from pmd_beamphysics.units import nice_array, nice_scale_prefix
+from beamphysics.units import nice_array, nice_scale_prefix
 from pydantic import ConfigDict, Field
 from typing_extensions import Literal
 

--- a/impact/z/run.py
+++ b/impact/z/run.py
@@ -18,8 +18,8 @@ import h5py
 import numpy as np
 from lume import tools as lume_tools
 from lume.base import CommandWrapper
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import pmd_unit
+from beamphysics import ParticleGroup
+from beamphysics.units import pmd_unit
 from typing_extensions import override
 
 from . import tools

--- a/impact/z/types.py
+++ b/impact/z/types.py
@@ -9,8 +9,8 @@ import annotated_types
 import numpy as np
 import pydantic
 import pydantic_core
-from pmd_beamphysics import ParticleGroup
-from pmd_beamphysics.units import pmd_unit
+from beamphysics import ParticleGroup
+from beamphysics.units import pmd_unit
 from rich.pretty import pretty_repr
 from typing_extensions import Literal, NotRequired, TypeAlias, TypedDict, override
 from typing import Annotated

--- a/impact/z/units.py
+++ b/impact/z/units.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pmd_beamphysics.units import e_charge, known_unit, mec2, pmd_unit
+from beamphysics.units import e_charge, known_unit, mec2, pmd_unit
 from typing import Annotated
 from .types import NDArray
 


### PR DESCRIPTION
This replaces all `pmd_beamphysics` with `beamphysics` corresponding to https://github.com/ChristopherMayes/openPMD-beamphysics/releases/tag/v0.14.0.

openpmd-beamphysics >= 0.14.0 is now required.