### PR TITLE
CI: fix pypi upload Python version + bump actions

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python 3.10
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install pypa/build
         run: >-
           python -m


### PR DESCRIPTION
* `a: 3.10` becomes a floating point `3.1` - this is why the PyPI upload just failed in the last release
   * The simple fix is just quoting it. Next time we'll see that will be Python 3.20 😁 
   * This was introduced in https://github.com/ChristopherMayes/lume-impact/pull/58 and this is our first new release after that PR
* Bump absolutely ancient versions in the PyPI workflow