### PR TITLE
CI/BLD: can't use direct dep and upload to pypi (distgen)

### DIFF
--- a/.github/workflows/tests-pip.yml
+++ b/.github/workflows/tests-pip.yml
@@ -27,6 +27,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python-version }}"
+      - name: Install non-PyPI dependencies
+        shell: bash -l -e -o pipefail {0}
+        run: |
+          python -m pip install git+https://github.com/ColwynGulliford/distgen.git@v2.2.5
       - name: Install LUME-Impact
         shell: bash -l -e -o pipefail {0}
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "bokeh",
   # Distgen is not yet on PyPI:
   # "distgen",
-  "distgen @ git+https://github.com/ColwynGulliford/distgen.git@v2.2.5",
+  # "distgen @ git+https://github.com/ColwynGulliford/distgen.git@v2.2.5",
   "lume-base",
   "matplotlib",
   "numpy",


### PR DESCRIPTION
While direct dependencies work with `pip install .`, PyPI won't even let you upload a package with it.
I suppose it's sensible as deps should only come from PyPI at that point. This is a new one to me!

[Error ref](https://github.com/ChristopherMayes/lume-impact/actions/runs/24482795706/job/71550982972):
```
400 Can't have direct dependency: distgen @                   
         git+https://github.com/ColwynGulliford/distgen.git@v2.2.5. See         
         https://packaging.python.org/specifications/core-metadata for more     
         information.</title>                                                   
```