### PR TITLE
MNT/BUG: remove mutable default arguments

### DIFF
--- a/impact/control.py
+++ b/impact/control.py
@@ -1,4 +1,5 @@
 import json
+from typing import Sequence
 
 
 class ControlGroup:
@@ -39,7 +40,7 @@ class ControlGroup:
 
     def __init__(
         self,
-        ele_names=[],
+        ele_names: Sequence[str] = (),
         var_name=None,
         # If underlying attribute is different
         attributes=None,
@@ -50,7 +51,7 @@ class ControlGroup:
         absolute=False,
         name=None,
     ):
-        self.ele_names = ele_names  # Link these.
+        self.ele_names = list(ele_names)  # Link these.
         self.var_name = var_name
 
         self.attributes = attributes

--- a/impact/impact.py
+++ b/impact/impact.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import Sequence
 import warnings
 from .parsers import (
     parse_impact_input,
@@ -1000,12 +1001,12 @@ class Impact(CommandWrapper):
 
     def plot(
         self,
-        y=["sigma_x", "sigma_y"],
+        y: str | Sequence[str] = ("sigma_x", "sigma_y"),
         x="mean_z",
         xlim=None,
         ylim=None,
         ylim2=None,
-        y2=[],
+        y2: str | Sequence[str] = (),
         nice=True,
         include_layout=True,
         include_labels=False,
@@ -1019,6 +1020,10 @@ class Impact(CommandWrapper):
         **kwargs,
     ):
         """ """
+        if not isinstance(y, str):
+            y = list(y)
+        if not isinstance(y2, str):
+            y2 = list(y2)
 
         # Just plot fieldmaps if there are no stats
         if "stats" not in self.output:

--- a/impact/lattice.py
+++ b/impact/lattice.py
@@ -1,4 +1,6 @@
 # import numpy as np
+from typing import Sequence
+
 from . import parsers
 from .parsers import itype_of, VALID_KEYS
 
@@ -275,7 +277,9 @@ def ele_shapes(eles):
 
 
 # -----------------------------------------------------------------
-def remove_element_types(lattice, types=["stop", "comment", "write_beam", "wakefield"]):
+def remove_element_types(
+    lattice, types: Sequence[str] = ("stop", "comment", "write_beam", "wakefield")
+):
     """
     Removes particular types of elements from a lattice (list of elements)
     """
@@ -380,7 +384,7 @@ def insert_ele_by_s(ele, eles, verbose=False):
 # Constructors
 
 
-def new_write_beam(name=None, s=0, filename=None, sample_frequency=1, ref_eles=[]):
+def new_write_beam(name=None, s=0, filename=None, sample_frequency=1, ref_eles=()):
     """
     returns a new write_beam element.
 

--- a/impact/model/config.py
+++ b/impact/model/config.py
@@ -504,7 +504,7 @@ def _make_particle_actions(impact: Any, config: ParticlesConfig) -> list[Action]
 
 def make_actions(
     impact: Impact,
-    config: VariableMappingConfig,
+    config: VariableMappingConfig | None = None,
     stat_size_expansion: float = 1.1,
 ) -> list[Action]:
     """Build variable actions for every element attribute, header key, and output
@@ -521,6 +521,9 @@ def make_actions(
         NDVariable shape when ``StatsConfig.max_size`` is not set.
     """
     actions: list[Action] = []
+    if config is None:
+        config = VariableMappingConfig()
+
     if config.header is not None:
         actions += _make_header_actions(impact, config.header)
     if config.elements is not None:

--- a/impact/model/distgen/config.py
+++ b/impact/model/distgen/config.py
@@ -347,7 +347,7 @@ def _process_start_config(
 
 def make_actions(
     gen: Generator,
-    config: DistgenVariableMappingConfig = DistgenVariableMappingConfig(),
+    config: DistgenVariableMappingConfig | None = None,
 ) -> list[DistgenInputAction]:
     """Build variable mappings from a distgen Generator and config.
 
@@ -364,6 +364,9 @@ def make_actions(
     list[DistgenInputAction]
     """
     actions: list[DistgenInputAction] = []
+    if config is None:
+        config = DistgenVariableMappingConfig()
+
     inp_cfg = config.inputs
     if inp_cfg is None:
         return actions

--- a/impact/model/distgen/model.py
+++ b/impact/model/distgen/model.py
@@ -29,9 +29,11 @@ class LUMEDistgenModel(FinalParticlesMixIn, ActionModel[Generator]):
     def from_generator(
         cls,
         gen: Generator,
-        config: DistgenVariableMappingConfig = DistgenVariableMappingConfig(),
+        config: DistgenVariableMappingConfig | None = None,
         **kwargs,
     ) -> "LUMEDistgenModel":
+        if config is None:
+            config = DistgenVariableMappingConfig()
         return cls(gen, make_actions(gen, config), **kwargs)
 
     def _set(self, values: dict[str, Any]) -> None:

--- a/impact/model/model.py
+++ b/impact/model/model.py
@@ -65,7 +65,7 @@ class LUMEImpactModel(InitialParticlesMixIn, FinalParticlesMixIn, ActionModel[Im
     def from_impact(
         cls,
         impact: Impact,
-        config: VariableMappingConfig = VariableMappingConfig(),
+        config: VariableMappingConfig | None = None,
         **kwargs,
     ) -> "LUMEImpactModel":
         """

--- a/impact/plot.py
+++ b/impact/plot.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 from beamphysics.units import nice_scale_prefix, plottable_array_and_units
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
@@ -209,8 +211,8 @@ def plot_layout(
 
 def plot_stats_with_layout(
     impact_object,
-    ykeys=["sigma_x", "sigma_y"],
-    ykeys2=["mean_kinetic_energy"],
+    ykeys: str | Sequence[str] = ("sigma_x", "sigma_y"),
+    ykeys2: str | Sequence[str] = ("mean_kinetic_energy",),
     xkey="mean_z",
     xlim=None,
     ylim=None,
@@ -247,6 +249,11 @@ def plot_stats_with_layout(
         return_figure: return the figure object for further manipulation. Default: False
 
     """
+    if not isinstance(ykeys, str):
+        ykeys = list(ykeys)
+    if not isinstance(ykeys2, str):
+        ykeys2 = list(ykeys2)
+
     I = impact_object  # convenience
 
     if include_layout:

--- a/impact/tools.py
+++ b/impact/tools.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from copy import deepcopy
 from hashlib import blake2b
+from typing import Sequence
 
 import numpy as np
 import psutil
@@ -82,10 +83,11 @@ def execute2(cmd, timeout=None, cwd=None):
     return output
 
 
-def runs_script(runscript=[], dir=None, log_file=None, verbose=True):
+def runs_script(runscript: Sequence[str] = (), dir=None, log_file=None, verbose=True):
     """
     Basic driver for running a script in a directory. Will
     """
+    runscript = list(runscript)
 
     # Save init dir
     init_dir = os.getcwd()
@@ -162,7 +164,12 @@ def find_executable(exename=None, envname=None):
     raise ValueError(f"Could not find executable: exename={exename}, envname={envname}")
 
 
-def find_property(s, key="name", separator=":", delims=[" ", ",", ";"]):
+def find_property(
+    s: str,
+    key: str = "name",
+    separator: str = ":",
+    delims: Sequence[str] = (" ", ",", ";"),
+):
     """
     Find property of the form key+delim+value
 

--- a/impact/z/run.py
+++ b/impact/z/run.py
@@ -668,7 +668,7 @@ class ImpactZ(CommandWrapper):
         xlim=None,
         ylim=None,
         ylim2=None,
-        y2=[],
+        y2: str | Sequence[str] = (),
         nice=True,
         include_layout=True,
         include_labels=False,
@@ -719,6 +719,8 @@ class ImpactZ(CommandWrapper):
         fig : matplotlib.pyplot.figure.Figure
             The plot figure for further customizations or `None` if `return_figure` is set to False.
         """
+        if not isinstance(y2, str):
+            y2 = list(y2)
 
         if self.output is None:
             raise RuntimeError(


### PR DESCRIPTION
## Description
- Adjusts various signatures to avoid mutable default arguments

## Context
One of the cardinal sins of python, I'm surprised this had never burned us before with how pervasive it was.  Default arguments are created once at function/method creation, and are shared amongst all instances of the function / method.  

For example, this means that if you ever modified `ControlGroup.ele_names` ALL future instances of `ControlGroup` would have that same modification, bleeding state across the session.  In many cases we never actually modified the mutable defaults, but that doesn't mean we should open ourselves up to this hard-to-diagnose bug