### PR TITLE
MNT: flag Impact as un-finished at the start of each new run

### DIFF
--- a/impact/impact.py
+++ b/impact/impact.py
@@ -237,6 +237,7 @@ class Impact(CommandWrapper):
         self.setup_workdir(workdir)
         self.vprint("Configured to run in:", self.path)
         self.configured = True
+        self.finished = False
 
     def input_parser(self, path):
         return parse_impact_input(path, verbose=self.verbose)
@@ -509,6 +510,7 @@ class Impact(CommandWrapper):
 
         # Clear output
         self.output = {}
+        self.finished = False
 
         # Autophase
         autophase_settings = self.autophase_bookkeeper()


### PR DESCRIPTION
## Description
- sets `Impact.finished=False` at the start of each impact run and during configuration

## Context
If you completed a run, changed parameters such that the simulation would fail, then rerun, Impact would still report itself as finished successfully.  I'd like to be able to track the success of simulations and roll back settings on failure (in downstream apps, to be clear.  This is the only change I'm proposing to lume-impact for now)

The Impact-Z wrapper does this as well.