### PR TITLE
BUG/BLD: Resolve DISTGEN_YAML path with pathlib, conda feedstock test…

### DIFF
--- a/impact/tests/model/test_distgen_model.py
+++ b/impact/tests/model/test_distgen_model.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 from distgen import Generator
@@ -11,15 +11,16 @@ from impact.model.distgen.model import LUMEDistgenModel
 from impact.model.actions import HeaderAction
 
 
-DISTGEN_YAML = os.path.join(
-    os.path.dirname(__file__),
-    "../../../docs/examples/templates/lcls_injector/distgen.yaml",
+DISTGEN_YAML = (
+    Path(__file__).resolve().parents[3]
+    / "docs/examples/templates/lcls_injector/distgen.yaml"
 )
 
 
 @pytest.fixture(scope="module")
 def gen():
-    return Generator(DISTGEN_YAML)
+    # distgen assumes non-string input is a parsed yaml as dictionary...
+    return Generator(str(DISTGEN_YAML))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
# Description
- Resolve `DISTGEN_YAML` path fully with pathlib

# Context

conda feedstock tests come with a hardcoded `$PREFIX` in their paths, which don't get expanded properly.  The previous path handling didn't work, and resulted in errors like: ([failed tests](https://github.com/conda-forge/lume-impact-feedstock/actions/runs/30117038802/job/89560179399?pr=47))

```
ERROR tests/model/test_distgen_model.py::test_combined_model_has_header_bcurr - ValueError: ERROR: parsing unsuccessful, could not read $PREFIX/lib/python3.10/site-packages/impact/tests/model/../../../docs/examples/templates/lcls_injector/distgen.yaml
ERROR tests/model/test_distgen_model.py::test_register_distgen_action_on_combined - ValueError: ERROR: parsing unsuccessful, could not read $PREFIX/lib/python3.10/site-packages/impact/tests/model/../../../docs/examples/templates/lcls_injector/distgen.yaml
```

I wish there were a more direct way of testing this, but short of completely reproducing the conda-forge ci infra this is the best we can do